### PR TITLE
добавлены пункт N5 и N6

### DIFF
--- a/pyramid.cpp
+++ b/pyramid.cpp
@@ -7,12 +7,7 @@ Pyramid::Pyramid(QWidget *parent) :
 {
 
     ui->setupUi(this);
-    ui->image_label->setGeometry(50,50,500,500);
-//    QImage *image = new QImage(500, 500, QImage::Format_Mono);
-    //image->setColorCount(1);
-   // image->setColor(0, qRgba(255, 255, 255, 255));
-    //ui->image_label->setPixmap(QPixmap::fromImage(*image));
-   // ui->label_size2->setText(QString::number(image->height())+'x'+QString::number(image->width()));
+    //ui->image_label->setGeometry(50,50,500,500);
     QScrollArea *area=new QScrollArea;
     ui->verticalLayout->addWidget(area);
     area->setWidget(ui->image_label);
@@ -38,6 +33,13 @@ void Pyramid::on_actionOpen_triggered()
     if (!fileName.isEmpty())
     {
             QImage image(fileName);
+            if (hash.contains(fileName))
+            {
+                QMessageBox::information(this, tr("Warning!"),
+                                         tr("Этот файл уже открыт,попробуйте другой").arg(fileName));
+
+            }
+            else{
             ui->comboBox->addItem(fileName);
             ui->comboBox->setCurrentText(fileName);
             if (image.isNull())
@@ -46,6 +48,8 @@ void Pyramid::on_actionOpen_triggered()
                                          tr("Cannot load %1.").arg(fileName));
                 return;
             }
+            ui->comboBox_layers->setCurrentIndex(0);
+            ui->comboBox_layers->clear();
             //************************************************************************************************
             //Вызываем дополнительное диалоговое окно,для получения количества слоев пирамиды
             bool okno;
@@ -54,10 +58,11 @@ void Pyramid::on_actionOpen_triggered()
 
             picture=new QPixmap(QPixmap::fromImage(image));
             ui->image_label->resize(picture->width(),picture->height());
-    }
             gener_pics();
+    }
 
-   // ui->image_label->setPixmap(*picture);
+
+}
 }
 
 int Pyramid::getLayers() const
@@ -71,10 +76,50 @@ void Pyramid::setLayers(int value)
 }
 void Pyramid::gener_pics()
 {
+    ui->comboBox_layers->clear();
     for(int i=0;i<getLayers();i++)
     {
         ui->comboBox_layers->addItem(QString::number(i));
         pics.insert(i,picture->toImage().scaled(picture->width()/pow(2,i),picture->height()/pow(2,i)));
     }
-    ui->image_label->setPixmap(QPixmap::fromImage(pics[0]));
+    hash.insert(getName(),pics);
+    changelayers(0);
+}
+void Pyramid::gener_hash(QString name)
+{
+    ui->comboBox_layers->clear();
+    for(int i=0;i<hash.value(name).size();i++)
+    {
+       ui->comboBox_layers->addItem(QString::number(i));
+    }
+    hash.value(name).value(0);
+    setName(name);
+    ui->image_label->setPixmap(QPixmap::fromImage(hash.value(name).value(0)));
+}
+
+QString Pyramid::getName() const
+{
+    return name;
+}
+
+void Pyramid::setName(const QString &value)
+{
+    name = value;
+}
+
+void Pyramid::changelayers(int layernumber)
+{
+    ui->image_label->setPixmap(QPixmap::fromImage(hash.value(getName()).value(layernumber)).scaled(picture->width(),picture->height()));
+    ui->label_size2->setText(QString::number(hash.value(getName()).value(layernumber).width())+"x"+QString::number(hash.value(getName()).value(layernumber).height()));
+}
+
+void Pyramid::on_comboBox_layers_currentIndexChanged(int index)
+{
+    changelayers(index);
+}
+
+void Pyramid::on_comboBox_currentIndexChanged(const QString &arg1)
+{
+
+    gener_hash(arg1);
 }

--- a/pyramid.h
+++ b/pyramid.h
@@ -21,16 +21,26 @@ public:
     int getLayers() const;
     void setLayers(int value);
 
+    QString getName() const;
+    void setName(const QString &value);
+
 private slots:
     void on_actionClose_triggered();
     void gener_pics();
     void on_actionOpen_triggered();
+    void gener_hash(QString name);
+    void changelayers(int layernumber);
+    void on_comboBox_layers_currentIndexChanged(int index);
+
+    void on_comboBox_currentIndexChanged(const QString &arg1);
 
 private:
     Ui::Pyramid *ui;
     QPixmap *picture;
     QHash<int,QImage> pics;
     int layers;
+    QHash<QString,QHash<int,QImage>> hash;
+    QString name;
 };
 
 #endif // PYRAMID_H


### PR DESCRIPTION
Должна быть предусмотрена возможность произвольного переключения между слоями
и оригинальным изображением с отображением номера слоя и его размера в пикселях.
(т.е слои можно "листать", например с помощью combobox). При отображении каждый
слой должен быть увеличен до размера оригинального изображения (таким образом
содержимое его “замылится”).
6. Реализовать открытие нескольких файлов с возможностью их переключения.
Отобразить список открытых файлов с помощью комбобокса. Список отсортировать в
порядке увеличения диагонали изображения.
